### PR TITLE
Plugin packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
 
     - name: Install 7Zip (Windows)
       if: matrix.os == 'windows-latest'
@@ -22,49 +24,20 @@ jobs:
     - name: Get SC source code
       run: git clone https://github.com/supercollider/supercollider.git ${{github.workspace}}/supercollider
 
-#    - name: Create Build Environment
-#      # Some projects don't allow in-source building, so create a separate build directory
-#      # We'll use this as our working directory for all subsequent commands
-#      run: cmake -E make_directory ${{github.workspace}}/build
-
-#    - name: Configure CMake (Unix)
-#      shell: bash
-#      if: matrix.os != 'windows-latest'
-#      working-directory: ${{github.workspace}}/build
-#      run: cmake .. -DCMAKE_BUILD_TYPE='Release' -DSC_PATH=${{github.workspace}}/supercollider -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install
-
-#    - name: Configure CMake (Windows)
-#      if: matrix.os == 'windows-latest'
-#      shell: pwsh
-#      working-directory: ${{github.workspace}}\build
-#      run: cmake .. -DCMAKE_BUILD_TYPE='Release' -DSC_PATH=${{github.workspace}}\supercollider -DCMAKE_INSTALL_PREFIX=${{github.workspace}}\build\install
-
-#    - name: Build (Unix)
-#      if: matrix.os != 'windows-latest'
-#      working-directory: ${{github.workspace}}/build
-#      shell: bash
-#      run: cmake --build . --config "Release" --target install
-
-#    - name: Build (Windows)
-#      working-directory: ${{github.workspace}}\build
-#      if: matrix.os == 'windows-latest'
-#      shell: pwsh
-#      run: cmake --build . --config "Release" --target install
-
     - name: Build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: bash win-build.sh ./supercollider
+      run: bash win-build.sh ${{github.workspace}}\supercollider
 
     - name: Build (Linux)
       if: matrix.os == 'ubuntu-18.04'
       shell: bash
-      run: bash linux-build.sh ./supercollider
+      run: bash linux-build.sh ${{github.workspace}}/supercollider
 
-    - name: Build (Windows)
+    - name: Build (Mac OS X)
       if: matrix.os == 'macos-latest'
       shell: bash
-      run: bash mac-build.sh ./supercollider
+      run: bash mac-build.sh ${{github.workspace}}/supercollider
 
       # Gather all files in a zip
     - name: Zip up build (Unix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: pwsh
       run: |
-        copy sc/* build/mi-UGens
+        xcopy sc build\mi-UGens\ /E
         copy build_artifacts/* build/mi-UGens
 
       # Gather all files in a zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Prepare library for zip file
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: copy sc\* **\build\**.dll mi-UGens
+      run: copy sc\*  mi-UGens; copy **\build\**.dll mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Unix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,19 +39,32 @@ jobs:
       shell: bash
       run: bash mac-build.sh ${{github.workspace}}/supercollider
 
+    - name: Create Build Directory
+      run: cmake -E make_directory ${{github.workspace}}/mi-UGens
+
+    - name: Prepare library for zip file
+      if: matrix.os != 'windows-latest'
+      shell: bash
+      run: cp **/build/**.dylib **/build/**.so mi-UGens
+
+    - name: Prepare library for zip file
+      if: matrix.os == 'windows-latest'
+      shell: pwsh
+      run: copy **/build/**.dll mi-UGens
+
       # Gather all files in a zip
     - name: Zip up build (Unix)
       if: matrix.os != 'windows-latest'
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: zip -r mi-UGens-${{runner.os}} install/mi-UGens
+      run: zip -r mi-UGens-${{runner.os}} mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
       working-directory: ${{github.workspace}}\build
-      run: Compress-7Zip "install\mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
+      run: Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,19 +52,16 @@ jobs:
 #      run: cmake --build . --config "Release" --target install
 
     - name: Build (Windows)
-      working-directory: ${{github.workspace}}\build
       if: matrix.os == 'windows-latest'
       shell: pwsh
       run: sh win-build.sh
 
     - name: Build (Linux)
-      working-directory: ${{github.workspace}}\build
       if: matrix.os == 'ubuntu-18.04'
       shell: bash
       run: sh linux-build.sh
 
     - name: Build (Windows)
-      working-directory: ${{github.workspace}}\build
       if: matrix.os == 'macos-latest'
       shell: bash
       run: sh mac-build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,11 @@ jobs:
     - name: Zip up build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: Compress-7Zip "build\mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
+      working-directory: ${{github.workspace}}\build
+      run: |
+        Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
+        dir
+        dir mi-UGens
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,14 +61,12 @@ jobs:
     - name: Zip up build (Unix)
       if: matrix.os != 'windows-latest'
       shell: bash
-      working-directory: ${{github.workspace}}/build
       run: zip -r mi-UGens-${{runner.os}} mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      working-directory: ${{github.workspace}}\build
       run: Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
 
     - name: Check if release has been created

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,34 +40,29 @@ jobs:
       run: bash mac-build.sh ${{github.workspace}}/supercollider
 
     - name: Create Build Directory
-      run: cmake -E make_directory ${{github.workspace}}/mi-UGens
+      run: cmake -E make_directory ${{github.workspace}}/build/mi-UGens
 
     - name: Prepare library for zip file
       if: matrix.os == 'ubuntu-18.04'
       shell: bash
-      run: cp -r sc/* **/build/**.so mi-UGens
-
-    - name: Prepare library for zip file
-      if: matrix.os == 'macos-latest'
-      shell: bash
-      run: ls -l . && cp -r sc/* **.scx mi-UGens
+      run: cp -r sc/* **/build/**.so build/mi-UGens
 
     - name: Prepare library for zip file
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: copy sc\* mi-UGens; copy **\build\**.dll mi-UGens
+      run: copy sc\* mi-UGens; copy **\build\**.dll build/mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Unix)
       if: matrix.os != 'windows-latest'
       shell: bash
-      run: zip -r mi-UGens-${{runner.os}} mi-UGens
+      run: zip -r mi-UGens-${{runner.os}} build/mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
+      run: Compress-7Zip "build\mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,11 @@ jobs:
     - name: Zip up build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
+      working-directory: ${{github.workspace}}\build
       run: |
-        cd build
         Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
         dir
+        dir mi-UGens
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,14 @@ jobs:
       run: cmake -E make_directory ${{github.workspace}}/mi-UGens
 
     - name: Prepare library for zip file
-      if: matrix.os != 'windows-latest'
+      if: matrix.os == 'ubuntu-18.04'
       shell: bash
-      run: cp **/build/**.dylib **/build/**.so mi-UGens
+      run: cp **/build/**.so mi-UGens
+
+    - name: Prepare library for zip file
+      if: matrix.os == 'macos-latest'
+      shell: bash
+      run: cp **/build/**.dylib mi-UGens
 
     - name: Prepare library for zip file
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,34 +22,52 @@ jobs:
     - name: Get SC source code
       run: git clone https://github.com/supercollider/supercollider.git ${{github.workspace}}/supercollider
 
-    - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
-      run: cmake -E make_directory ${{github.workspace}}/build
+#    - name: Create Build Environment
+#      # Some projects don't allow in-source building, so create a separate build directory
+#      # We'll use this as our working directory for all subsequent commands
+#      run: cmake -E make_directory ${{github.workspace}}/build
 
-    - name: Configure CMake (Unix)
-      shell: bash
-      if: matrix.os != 'windows-latest'
-      working-directory: ${{github.workspace}}/build
-      run: cmake .. -DCMAKE_BUILD_TYPE='Release' -DSC_PATH=${{github.workspace}}/supercollider -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install
+#    - name: Configure CMake (Unix)
+#      shell: bash
+#      if: matrix.os != 'windows-latest'
+#      working-directory: ${{github.workspace}}/build
+#      run: cmake .. -DCMAKE_BUILD_TYPE='Release' -DSC_PATH=${{github.workspace}}/supercollider -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install
 
-    - name: Configure CMake (Windows)
-      if: matrix.os == 'windows-latest'
-      shell: pwsh
-      working-directory: ${{github.workspace}}\build
-      run: cmake .. -DCMAKE_BUILD_TYPE='Release' -DSC_PATH=${{github.workspace}}\supercollider -DCMAKE_INSTALL_PREFIX=${{github.workspace}}\build\install
+#    - name: Configure CMake (Windows)
+#      if: matrix.os == 'windows-latest'
+#      shell: pwsh
+#      working-directory: ${{github.workspace}}\build
+#      run: cmake .. -DCMAKE_BUILD_TYPE='Release' -DSC_PATH=${{github.workspace}}\supercollider -DCMAKE_INSTALL_PREFIX=${{github.workspace}}\build\install
 
-    - name: Build (Unix)
-      if: matrix.os != 'windows-latest'
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      run: cmake --build . --config "Release" --target install
+#    - name: Build (Unix)
+#      if: matrix.os != 'windows-latest'
+#      working-directory: ${{github.workspace}}/build
+#      shell: bash
+#      run: cmake --build . --config "Release" --target install
+
+#    - name: Build (Windows)
+#      working-directory: ${{github.workspace}}\build
+#      if: matrix.os == 'windows-latest'
+#      shell: pwsh
+#      run: cmake --build . --config "Release" --target install
 
     - name: Build (Windows)
       working-directory: ${{github.workspace}}\build
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: cmake --build . --config "Release" --target install
+      run: sh win-build.sh
+
+    - name: Build (Linux)
+      working-directory: ${{github.workspace}}\build
+      if: matrix.os == 'ubuntu-18.04'
+      shell: bash
+      run: sh linux-build.sh
+
+    - name: Build (Windows)
+      working-directory: ${{github.workspace}}\build
+      if: matrix.os == 'macos-latest'
+      shell: bash
+      run: sh mac-build.sh
 
       # Gather all files in a zip
     - name: Zip up build (Unix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,6 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{github.workspace}}/build/mi-UGens-${{runner.os}}.zip
+        file: ${{github.workspace}}/mi-UGens-${{runner.os}}.zip
         asset_name: mi-UGens-${{runner.os}}.zip
         tag: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,8 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: pwsh
       run: |
-        copy sc\* build\mi-UGens
-        copy **\build\**.dll build/mi-UGens
+        copy sc/* build/mi-UGens
+        copy build_artifacts/* build/mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Unix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,17 +45,17 @@ jobs:
     - name: Prepare library for zip file
       if: matrix.os == 'ubuntu-18.04'
       shell: bash
-      run: cp **/build/**.so mi-UGens
+      run: cp -r sc/* **/build/**.so mi-UGens
 
     - name: Prepare library for zip file
       if: matrix.os == 'macos-latest'
       shell: bash
-      run: cp **/build/**.dylib mi-UGens
+      run: ls -l && cp -r sc/* **/build/**.so mi-UGens
 
     - name: Prepare library for zip file
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: copy **/build/**.dll mi-UGens
+      run: copy sc\* **\build\**.dll mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Unix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,12 @@ jobs:
     - name: Prepare library for zip file
       if: matrix.os == 'macos-latest'
       shell: bash
-      run: ls -l **/build && cp -r sc/* **/build/**.so mi-UGens
+      run: ls -l . && cp -r sc/* **.scx mi-UGens
 
     - name: Prepare library for zip file
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: copy sc\*  mi-UGens; copy **\build\**.dll mi-UGens
+      run: copy sc\* mi-UGens; copy **\build\**.dll mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Unix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Prepare library for zip file
       if: matrix.os == 'macos-latest'
       shell: bash
-      run: ls -l && cp -r sc/* **/build/**.so mi-UGens
+      run: ls -l **/build && cp -r sc/* **/build/**.so mi-UGens
 
     - name: Prepare library for zip file
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,17 +54,17 @@ jobs:
     - name: Build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: sh win-build.sh
+      run: bash win-build.sh ./supercollider
 
     - name: Build (Linux)
       if: matrix.os == 'ubuntu-18.04'
       shell: bash
-      run: sh linux-build.sh
+      run: bash linux-build.sh ./supercollider
 
     - name: Build (Windows)
       if: matrix.os == 'macos-latest'
       shell: bash
-      run: sh mac-build.sh
+      run: bash mac-build.sh ./supercollider
 
       # Gather all files in a zip
     - name: Zip up build (Unix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,8 @@ jobs:
       shell: pwsh
       run: |
         cd build
-        dir
         Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
+        dir
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,6 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{github.workspace}}/mi-UGens-${{runner.os}}.zip
+        file: ${{github.workspace}}/build/mi-UGens-${{runner.os}}.zip
         asset_name: mi-UGens-${{runner.os}}.zip
         tag: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,10 +67,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: pwsh
       working-directory: ${{github.workspace}}\build
-      run: |
-        Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
-        dir
-        dir mi-UGens
+      run: Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip -PreserveDirectoryRoot
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,19 +50,25 @@ jobs:
     - name: Prepare library for zip file
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: copy sc\* build\mi-UGens; copy **\build\**.dll build/mi-UGens
+      run: |
+        copy sc\* build\mi-UGens
+        copy **\build\**.dll build/mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Unix)
       if: matrix.os != 'windows-latest'
       shell: bash
-      run: cd build && zip -r mi-UGens-${{runner.os}} mi-UGens
+      run: |
+        cd build
+        zip -r mi-UGens-${{runner.os}} mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: cd build; Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
+      run: |
+        cd build
+        Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,95 @@
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  build:
+
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-18.04, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install 7Zip (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: powershell
+      run: Install-Module 7Zip4PowerShell -Force -Verbose
+
+    - name: Get SC source code
+      run: git clone https://github.com/supercollider/supercollider.git ${{github.workspace}}/supercollider
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake (Unix)
+      shell: bash
+      if: matrix.os != 'windows-latest'
+      working-directory: ${{github.workspace}}/build
+      run: cmake .. -DCMAKE_BUILD_TYPE='Release' -DSC_PATH=${{github.workspace}}/supercollider -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install
+
+    - name: Configure CMake (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: pwsh
+      working-directory: ${{github.workspace}}\build
+      run: cmake .. -DCMAKE_BUILD_TYPE='Release' -DSC_PATH=${{github.workspace}}\supercollider -DCMAKE_INSTALL_PREFIX=${{github.workspace}}\build\install
+
+    - name: Build (Unix)
+      if: matrix.os != 'windows-latest'
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: cmake --build . --config "Release" --target install
+
+    - name: Build (Windows)
+      working-directory: ${{github.workspace}}\build
+      if: matrix.os == 'windows-latest'
+      shell: pwsh
+      run: cmake --build . --config "Release" --target install
+
+      # Gather all files in a zip
+    - name: Zip up build (Unix)
+      if: matrix.os != 'windows-latest'
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      run: zip -r mi-UGens-${{runner.os}} install/mi-UGens
+
+      # Gather all files in a zip
+    - name: Zip up build (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: pwsh
+      working-directory: ${{github.workspace}}\build
+      run: Compress-7Zip "install\mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
+
+    - name: Check if release has been created
+      uses: mukunku/tag-exists-action@v1.0.0
+      id: checkTag
+      with:
+        tag: 'v1'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Publish build
+    - name: Create Release
+      if: steps.checkTag.outputs.exists == false
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: mi-UGens-${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{github.workspace}}/build/mi-UGens-${{runner.os}}.zip
+        asset_name: mi-UGens-${{runner.os}}.zip
+        tag: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,11 +66,7 @@ jobs:
     - name: Zip up build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      working-directory: ${{github.workspace}}\build
-      run: |
-        Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
-        dir
-        dir mi-UGens
+      run: Compress-7Zip "build\mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,19 +50,19 @@ jobs:
     - name: Prepare library for zip file
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: copy sc\* mi-UGens; copy **\build\**.dll build/mi-UGens
+      run: copy sc\* build\mi-UGens; copy **\build\**.dll build/mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Unix)
       if: matrix.os != 'windows-latest'
       shell: bash
-      run: zip -r mi-UGens-${{runner.os}} build/mi-UGens
+      run: cd build && zip -r mi-UGens-${{runner.os}} mi-UGens
 
       # Gather all files in a zip
     - name: Zip up build (Windows)
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: Compress-7Zip "build\mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
+      run: cd build; Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
 
     - name: Check if release has been created
       uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
       shell: pwsh
       run: |
         cd build
+        dir
         Compress-7Zip "mi-UGens" -ArchiveFileName "mi-UGens-${{runner.os}}.zip" -Format Zip
 
     - name: Check if release has been created


### PR DESCRIPTION
As discussed in #8 
This PR give the possibility to build and store artifacts on github releases (as this example on my fork: https://github.com/ndr-brt/mi-UGens/releases/tag/v0.0.23)
The release process will start pushing a tag in the format `vx.y.z`.

Every zip file then can be unzipped into the extensions folder of supercollider.