### PR TITLE
Use stable supercollider branch for automatic builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       run: Install-Module 7Zip4PowerShell -Force -Verbose
 
     - name: Get SC source code
-      run: git clone https://github.com/supercollider/supercollider.git ${{github.workspace}}/supercollider
+      run: git clone -b main https://github.com/supercollider/supercollider.git ${{github.workspace}}/supercollider
       
     # for windows we have to explicitly add the libsamplerate build job here, for some reason...
     - name: build_libsamplerate_win

--- a/.github/workflows/dispatch-build.yml
+++ b/.github/workflows/dispatch-build.yml
@@ -23,7 +23,7 @@ jobs:
       run: Install-Module 7Zip4PowerShell -Force -Verbose
 
     - name: Get SC source code
-      run: git clone https://github.com/supercollider/supercollider.git ${{github.workspace}}/supercollider
+      run: git clone -b main https://github.com/supercollider/supercollider.git ${{github.workspace}}/supercollider
     
     # for windows we have to explicitly add the libsamplerate build job here, for some reason...
     - name: build_libsamplerate_win


### PR DESCRIPTION
I suggest using stable SC branch for building the plugins. I modified both workflow files - the change should definitely be applied to the release building workflow. If the change to the other file is not desired, I'd be happy to revert it.

Context: as of February 2026 the develop branch of SC specifies a newer plugin API and thus building against it makes the plugins incompatible with the latest stable release (3.14).